### PR TITLE
Patch for #1595 and #1762 (incorrect URL)

### DIFF
--- a/PowerEditor/src/NppNotification.cpp
+++ b/PowerEditor/src/NppNotification.cpp
@@ -847,8 +847,8 @@ BOOL Notepad_plus::notify(SCNotification *notification)
 
 		case SCN_HOTSPOTDOUBLECLICK:
 		{
-			notifyView->execute(SCI_SETWORDCHARS, 0, (LPARAM)"abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789_-+.,:?&@=/%#()");
-
+			notifyView->execute(SCI_SETWORDCHARS, 0, (LPARAM)"abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789_-+*.,:;!?$&@=/%#()");
+		
 			int pos = notifyView->execute(SCI_GETCURRENTPOS);
 			int startPos = static_cast<int>(notifyView->execute(SCI_WORDSTARTPOSITION, pos, false));
 			int endPos = static_cast<int>(notifyView->execute(SCI_WORDENDPOSITION, pos, false));


### PR DESCRIPTION
URL's were getting cutoff when certain characters were included in the URL, they were not considered appropriate characters in the function.

Added the following deliminators to the function responsible for parsing a URL (in SCN_HOTSPOTDOUBLECLICK):
"!" ";" "$" "*"

Fixes issues #1595 and#1762
